### PR TITLE
docs: update `ddev get` to `ddev add-on get` in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,17 @@
 
 This extension is based on [dunglas/mercure](https://github.com/dunglas/mercure)s implementation.
 
-To install it, run `ddev get Rindula/ddev-mercure`.
+To install it, for DDEV v1.23.5 or above run
+
+```sh
+ddev add-on get Rindula/ddev-mercure
+```
+
+For earlier versions of DDEV run
+
+```sh
+ddev get Rindula/ddev-mercure
+```
 
 The mercurehost will be available under `mercure.${DDEV_HOSTNAME}`.
 So for `example.ddev.site` the url will be `mercure.example.ddev.site`.


### PR DESCRIPTION
In [DDEV 1.23.5](https://github.com/ddev/ddev/releases/tag/v1.23.5) the ddev get command was deprecated in favour of ddev add-on get.

This PR updates those references in the readme file. There may be some additional markdown improvements as well.

The changes were made manually, but the PR itself was automatically created - I'm doing over 100 of these. I apologise if its not 100% to the contributor standards required by this repo. Let me know if I need to change anything.