### PR TITLE
Don't start container on computer restart

### DIFF
--- a/docker-compose.mercure.yaml
+++ b/docker-compose.mercure.yaml
@@ -1,7 +1,7 @@
 services:
   mercure:
     image: dunglas/mercure:v0.16
-    restart: unless-stopped
+    restart: no
     container_name: "ddev-${DDEV_SITENAME}-mercure"
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}


### PR DESCRIPTION
If the service has the config `restart: unless-stopped`, the Docker container will start automatically when the computer is restarted without powering DDEV off. This is an unwanted behavior.

Official DDEV containers have either `restart: no` or don't use the directive at all (defaulting to `no`), so changing this here will align this add-on to the other add-ons.