### PR TITLE
Add ddev-generated flag

### DIFF
--- a/docker-compose.mercure.yaml
+++ b/docker-compose.mercure.yaml
@@ -1,3 +1,4 @@
+#ddev-generated
 services:
   mercure:
     image: dunglas/mercure:v0.16


### PR DESCRIPTION
DDEV add-on files require the `#ddev-generated` comment, so DDEV can know if the file is managed by DDEV and may therefore be overridden on updates or if the file be left intact, should the comment is missing.

https://github.com/Rindula/ddev-mercure/blob/04813215bd3f0c9d55a1e21e316b06555ff274b1/install.yaml#L49-L50